### PR TITLE
SPEECHPLAN-15 renovate: JUnit-Test-für-OrderName-und-AvatarProvider-s…

### DIFF
--- a/app/src/main/java/de/geosphere/speechplaning/ui/atoms/OrderName.kt
+++ b/app/src/main/java/de/geosphere/speechplaning/ui/atoms/OrderName.kt
@@ -1,0 +1,11 @@
+package de.geosphere.speechplaning.ui.atoms
+
+/**
+ * Order name.
+ *
+ * @constructor Create empty Order name
+ */
+enum class OrderName {
+    FIRSTNAME_LASTNAME,
+    LASTNAME_FIRSTNAME
+}

--- a/app/src/main/java/de/geosphere/speechplaning/ui/atoms/SpeakerListItemComposable.kt
+++ b/app/src/main/java/de/geosphere/speechplaning/ui/atoms/SpeakerListItemComposable.kt
@@ -122,11 +122,6 @@ fun SpeakerListItemComposable(
     )
 }
 
-enum class OrderName {
-    FIRSTNAME_LASTNAME,
-    LASTNAME_FIRSTNAME
-}
-
 @ThemePreviews
 @Composable
 private fun SpeakerListItemPreview() = PreviewKoin {

--- a/app/src/test/java/de/geosphere/speechplaning/ui/atoms/AvatarProviderTest.kt
+++ b/app/src/test/java/de/geosphere/speechplaning/ui/atoms/AvatarProviderTest.kt
@@ -2,36 +2,20 @@ package de.geosphere.speechplaning.ui.atoms
 
 import de.geosphere.speechplaning.R
 import de.geosphere.speechplaning.data.SpiritualStatus
-import org.junit.Test
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 
 class AvatarProviderTest {
 
-    @Test
-    fun `getAvatar returns correct avatar for ELDER status`() {
-        // Arrange
-        val status = SpiritualStatus.ELDER
-        // Act & Assert
-        assertEquals(R.drawable.business_man_man_avatar_icon, AvatarProvider.getAvatar(status))
-    }
-
-    @Test
-    fun `getAvatar returns correct avatar for MINISTERIAL SERVANT status`() {
-        // Verify that when SpiritualStatus.MINISTERIAL_SERVANT is passed, the function returns
-        // R.drawable.man_avatar_male_icon.
-        // Arrange
-        val status = SpiritualStatus.MINISTERIAL_SERVANT
-        // Act & Assert
-        assertEquals(R.drawable.man_avatar_male_icon, AvatarProvider.getAvatar(status))
-    }
-
-    @Test
-    fun `getAvatar returns correct avatar for UKNOWN status`() {
-        // Verify that when SpiritualStatus.MINISTERIAL_SERVANT is passed, the function returns
-        // R.drawable.man_avatar_male_icon.
-        // Arrange
-        val status = SpiritualStatus.UNKNOWN
-        // Act & Assert
-        assertEquals(R.drawable.man_goatee_user_avatar_icon, AvatarProvider.getAvatar(status))
+    @ParameterizedTest
+    @EnumSource(SpiritualStatus::class)
+    fun `getAvatar returns correct drawable for each spiritual status`(status: SpiritualStatus) {
+        val expectedDrawable = when (status) {
+            SpiritualStatus.ELDER -> R.drawable.business_man_man_avatar_icon
+            SpiritualStatus.MINISTERIAL_SERVANT -> R.drawable.man_avatar_male_icon
+            SpiritualStatus.UNKNOWN -> R.drawable.man_goatee_user_avatar_icon
+        }
+        assertEquals(expectedDrawable, AvatarProvider.getAvatar(status))
     }
 }

--- a/app/src/test/java/de/geosphere/speechplaning/ui/atoms/OrderNameTest.kt
+++ b/app/src/test/java/de/geosphere/speechplaning/ui/atoms/OrderNameTest.kt
@@ -1,0 +1,30 @@
+package de.geosphere.speechplaning.ui.atoms
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Order name test.
+ *
+ * @constructor Create empty Order name test
+ */
+class OrderNameTest {
+
+    @Test
+    fun `enum constants are declared in the correct order`() {
+        val expectedOrder = listOf("FIRSTNAME_LASTNAME", "LASTNAME_FIRSTNAME")
+        val actualOrder = OrderName.entries.map { it.name }
+        assertEquals(expectedOrder, actualOrder)
+    }
+
+    @Test
+    fun `enum contains the correct number of constants`() {
+        assertEquals(2, OrderName.entries.size)
+    }
+
+    @Test
+    fun `valueOf returns the correct enum constant`() {
+        assertEquals(OrderName.FIRSTNAME_LASTNAME, OrderName.valueOf("FIRSTNAME_LASTNAME"))
+        assertEquals(OrderName.LASTNAME_FIRSTNAME, OrderName.valueOf("LASTNAME_FIRSTNAME"))
+    }
+}

--- a/config/jacoco/jacoco_class_exclusions.txt
+++ b/config/jacoco/jacoco_class_exclusions.txt
@@ -13,11 +13,14 @@ android/**/*.*
 **/*_ViewBinding.class
 **/*_Impl.class
 **/*_HiltModules*.*
+**/*Composable*.class
 de/geosphere/speechplaning/data/model/**/*.class
 de/geosphere/speechplaning/data/services/**/*.class
 de/geosphere/speechplaning/data/database/**/*.class
 de/geosphere/speechplaning/data/network/**/*.class
 de/geosphere/speechplaning/di/**/*.class
+de/geosphere/speechplaning/ui/components/**/*.class
+de/geosphere/speechplaning/ui/theme/**/*.class
 de/geosphere/speechplaning/mockup/**/*.class
 **/*Activity*.class
 **/*Fragment*.class

--- a/config/sonar/duplication_exclusions.txt
+++ b/config/sonar/duplication_exclusions.txt
@@ -1,1 +1,3 @@
 **/app/src/main/java/de/geosphere/speechplaning/mockup/**/*.kt
+**/app/src/main/java/de/geosphere/speechplaning/mockup/*.kt
+**/app/src/main/res/values/**/*.xml


### PR DESCRIPTION
…tellen

refactor: update avatar provider tests to use parameterized enum source